### PR TITLE
Add test to manifest _currency ExpressionNode bug

### DIFF
--- a/djmoney/tests/model_tests.py
+++ b/djmoney/tests/model_tests.py
@@ -10,7 +10,7 @@ from .testapp.models import (ModelWithVanillaMoneyField,
     ModelRelatedToModelWithMoney, ModelWithChoicesMoneyField, BaseModel, InheritedModel, InheritorModel,
     SimpleModel, NullMoneyFieldModel, ModelWithDefaultAsDecimal, ModelWithDefaultAsFloat, ModelWithDefaultAsInt,
     ModelWithDefaultAsString, ModelWithDefaultAsStringWithCurrency, ModelWithDefaultAsMoney, ModelWithTwoMoneyFields,
-    ProxyModel)
+    ProxyModel, ModelWithNonMoneyField)
 import moneyed
 
 
@@ -169,6 +169,15 @@ class RelatedModelsTestCase(TestCase):
 
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money=Money("100.0", moneyed.ZWN))
         ModelRelatedToModelWithMoney.objects.get(moneyModel__money__lt=Money("1000.0", moneyed.ZWN))
+
+
+class NonMoneyTestCase(TestCase):
+
+    def testAllowExpressionNodesWithoutMoney(self):
+        """ allow querying on expression nodes that are not Money """
+        ModelWithNonMoneyField(money=Money(100.0), desc="hundred").save()
+        instance = ModelWithNonMoneyField.objects.filter(desc=F("desc")).get()
+        self.assertEqual(instance.desc, "hundred")
 
 
 class InheritedModelTestCase(TestCase):

--- a/djmoney/tests/testapp/models.py
+++ b/djmoney/tests/testapp/models.py
@@ -51,6 +51,11 @@ class ModelWithChoicesMoneyField(models.Model):
     )
 
 
+class ModelWithNonMoneyField(models.Model):
+    money = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
+    desc = models.CharField(max_length=10)
+
+
 class AbstractModel(models.Model):
     price1 = MoneyField(max_digits=10, decimal_places=2, default_currency='USD')
 


### PR DESCRIPTION
Add test to show that when querying for an `ExpressonNode` like
`F()` or `Q()` on a model with a `MoneyField`, extra _currency
columns added are added to the query erroneously.

https://github.com/jakewins/django-money/issues/101